### PR TITLE
Use an absolute uri for fetching the favicon

### DIFF
--- a/_includes/globals/mast-head.njk
+++ b/_includes/globals/mast-head.njk
@@ -19,7 +19,7 @@
         <meta name="twitter:card" content="summary_large_image">
         <meta name="twitter:image:alt" content="Screenshot of Håvard Brynjulfsen's website">
         <link href="{{ '/css/styles.css' | url }}" rel="stylesheet">
-        <link rel="icon" type="image/svg+xml" href="img/unicorn-circle.svg">
+        <link rel="icon" type="image/svg+xml" href="/img/unicorn-circle.svg">
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=G-YS2MB4B427"></script>


### PR DESCRIPTION
The problem with using a relative url is that the favicon is only shown on the frontpage, not on subpages